### PR TITLE
Changed SalePriceEffectiveDate from DateTime to string

### DIFF
--- a/src/Geta.GoogleProductFeed/Models/Entry.cs
+++ b/src/Geta.GoogleProductFeed/Models/Entry.cs
@@ -89,5 +89,8 @@ namespace Geta.GoogleProductFeed.Models
 
         [XmlElement("shipping_width", Namespace = "http://base.google.com/ns/1.0")]
         public string ShippingWidth { get; set; }
+        
+        [XmlElement("identifier_exists", Namespace = "http://base.google.com/ns/1.0")]
+        public string IdentifierExists { get; set; }
     }
 }


### PR DESCRIPTION
Changed SalePriceEffectiveDate from DateTime to string to support the expected date range and to omit when empty

Added option to set "identifier_exists" to "no" for products without GTIN and brand or MPN and brand